### PR TITLE
chore: harden health endpoint for uptime checks

### DIFF
--- a/docs/operations/monitoring-setup.md
+++ b/docs/operations/monitoring-setup.md
@@ -109,6 +109,15 @@ Our application automatically logs errors through:
 - **Expected Status**: 200
 - **Timeout**: 15 seconds
 
+## UptimeRobot (Free)
+- **Type**: HTTPS
+- **URL**: `https://<your-domain>/api/health`
+- **Method**: GET (HEAD also works)
+- **Interval**: 5 minutes (free plan cap)
+- **Keyword** (optional): `status":"healthy"`
+- **Timeout**: 10 seconds
+- **Alert**: hook up main on-call channel/email
+
 ### Health Check Endpoints
 
 #### `/api/health` (Public)

--- a/lib/health.test.ts
+++ b/lib/health.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { createHealthSnapshot } from './health';
+
+describe('createHealthSnapshot', () => {
+  it('returns a minimal healthy snapshot', () => {
+    const snapshot = createHealthSnapshot();
+
+    expect(snapshot.status).toBe('healthy');
+    expect(typeof snapshot.timestamp).toBe('string');
+    expect(typeof snapshot.uptime).toBe('number');
+    expect(snapshot.memory.total).toBeGreaterThan(0);
+    expect(snapshot.memory.used).toBeGreaterThanOrEqual(0);
+    expect(snapshot.environment).toBe(process.env.NODE_ENV || 'unknown');
+    expect(snapshot.version.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/health.ts
+++ b/lib/health.ts
@@ -1,0 +1,35 @@
+const BYTES_IN_MB = 1024 * 1024;
+
+export interface HealthSnapshot {
+  status: 'healthy';
+  timestamp: string;
+  uptime: number;
+  memory: {
+    used: number;
+    total: number;
+  };
+  environment: string;
+  version: string;
+}
+
+export const HEALTH_RESPONSE_HEADERS = {
+  'Cache-Control': 'no-store, no-cache, must-revalidate',
+  'Content-Type': 'application/json',
+};
+
+// Lightweight, dependency-free snapshot for external uptime checks.
+export function createHealthSnapshot(): HealthSnapshot {
+  const memoryUsage = process.memoryUsage();
+
+  return {
+    status: 'healthy',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+    memory: {
+      used: Math.round(memoryUsage.heapUsed / BYTES_IN_MB),
+      total: Math.round(memoryUsage.heapTotal / BYTES_IN_MB),
+    },
+    environment: process.env.NODE_ENV || 'unknown',
+    version: process.env.npm_package_version || '0.1.0',
+  };
+}


### PR DESCRIPTION
## Summary
- extract a reusable health snapshot helper and reuse it in /api/health (GET + HEAD) with no-cache headers
- force node runtime + disable ISR so uptime monitors always hit live data; add minimal unit test
- document UptimeRobot free-plan check settings in monitoring guide

## Testing
- ASDF_NODEJS_VERSION=22.15.0 PATH="/Users/phaedrus/.asdf/shims:/Users/phaedrus/.cargo/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/share/dotnet:~/.dotnet/tools:/usr/local/go/bin:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Applications/Racket v8.13/bin:/var/folders/jr/0kj0xfdd4s1ggs921sr2d7f80000gn/T/.tmpsyfonr:/Users/phaedrus/.npm-global/lib/node_modules/@openai/codex/vendor/aarch64-apple-darwin/path:/Users/phaedrus/.asdf/plugins/nodejs/shims:/Users/phaedrus/.asdf/installs/nodejs/22.15.0/bin:/Users/phaedrus/.antigravity/antigravity/bin:/Users/phaedrus/.opencode/bin:/Users/phaedrus/google-cloud-sdk/bin:/Users/phaedrus/.npm-global/bin:/Users/phaedrus/bin:/Users/phaedrus/.yarn/bin:/Users/phaedrus/.config/yarn/global/node_modules/.bin:/Users/phaedrus/.docker/bin:/Users/phaedrus/.asdf/shims:/Users/phaedrus/.asdf/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/phaedrus/.asdf/installs/python/3.10.14/bin:/Users/phaedrus/.asdf/installs/python/3.9.17/bin:/Users/phaedrus/.local/bin:/Users/phaedrus/.cargo/bin:/Users/phaedrus/.deno/bin:/Users/phaedrus/Library/pnpm:/Users/phaedrus/go/bin:/Users/phaedrus/Library/Python/3.9/bin:/Users/phaedrus/Library/Android/sdk/emulator:/Users/phaedrus/Library/Android/sdk/tools:/Users/phaedrus/Development/vimv:/Users/phaedrus/Development/codex/bin:/Users/phaedrus/.fzf/bin:/Users/phaedrus/go/bin" pnpm test
