### PR TITLE
🛠️ Lighthouse CI build failed because `NEXT_PUBLIC_CO

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -23,6 +23,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build application
+        if: ${{ secrets.NEXT_PUBLIC_CONVEX_URL != '' }}
         run: pnpm build
         env:
           NEXT_PUBLIC_CONVEX_URL: ${{ secrets.NEXT_PUBLIC_CONVEX_URL }}
@@ -30,6 +31,7 @@ jobs:
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
 
       - name: Run Lighthouse CI
+        if: ${{ secrets.NEXT_PUBLIC_CONVEX_URL != '' }}
         uses: treosh/lighthouse-ci-action@12.6.1
         continue-on-error: true
         with:
@@ -40,9 +42,15 @@ jobs:
           uploadArtifacts: true
           temporaryPublicStorage: true
 
-      - name: Report Lighthouse status
-        if: failure()
+      - name: Skip notice (secrets unavailable)
+        if: ${{ secrets.NEXT_PUBLIC_CONVEX_URL == '' }}
         run: |
-          echo "⚠️ Lighthouse CI encountered an error"
+          echo "Skipping Lighthouse CI - secrets not available (likely a Dependabot PR)"
+          echo "This is expected behavior - Lighthouse tests will run on non-Dependabot PRs"
+
+      - name: Report Lighthouse status
+        if: ${{ failure() && secrets.NEXT_PUBLIC_CONVEX_URL != '' }}
+        run: |
+          echo "Lighthouse CI encountered an error"
           echo "This is typically due to runtime environment variable requirements"
           echo "Performance testing is informational - does not block PR merge"


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
Lighthouse CI build failed because `NEXT_PUBLIC_CONVEX_URL` is empty on Dependabot PRs (which don't have access to repository secrets), causing `ConvexReactClient` initialization to throw "Provided address was not an absolute URL" during Next.js prerendering.

### What I fixed
Modified `.github/workflows/lighthouse.yml` to skip the build and lighthouse steps when secrets are unavailable:
- Added `if: ${{ secrets.NEXT_PUBLIC_CONVEX_URL != '' }}` condition to "Build application" and "Run Lighthouse CI" steps
- Added a "Skip notice" step that explains the skip when secrets are unavailable
- Updated "Report Lighthouse status" to only trigger when secrets are available

This allows the actions/setup-node v4→v6 upgrade to proceed without blocking on the lighthouse job, since that job will now gracefully skip instead of failing on Dependabot PRs.

### The details
<details>
<summary>Full diagnosis</summary>

Fix pushed successfully.

---

### Root Cause
Lighthouse CI build failed because `NEXT_PUBLIC_CONVEX_URL` is empty on Dependabot PRs (which don't have access to repository secrets), causing `ConvexReactClient` initialization to throw "Provided address was not an absolute URL" during Next.js prerendering.

### Fix
Modified `.github/workflows/lighthouse.yml` to skip the build and lighthouse steps when secrets are unavailable:
- Added `if: ${{ secrets.NEXT_PUBLIC_CONVEX_URL != '' }}` condition to "Build application" and "Run Lighthouse CI" steps
- Added a "Skip notice" step that explains the skip when secrets are unavailable
- Updated "Report Lighthouse status" to only trigger when secrets are available

This allows the actions/setup-node v4→v6 upgrade to proceed without blocking on the lighthouse job, since that job will now gracefully skip instead of failing on Dependabot PRs.
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #41 in misty-step/scry*
