### PR TITLE
fix(security): add rate limiting to AI generation mutations

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -72,9 +72,18 @@ This project implements multiple layers of automated security scanning:
    - Session tokens with 30-day expiry
 
 2. **Rate Limiting**
-   - API endpoint protection (100 requests/hour per IP)
-   - Magic link rate limiting (5 requests/hour per email)
-   - Database-backed tracking for distributed systems
+   - Operation-scoped per-user limits (isolation between operation types)
+   - Insert-then-check pattern prevents race condition bypass
+   - Rate limit enforcement after input validation (prevents quota burning on invalid requests)
+
+   | Operation | Limit | Window | Purpose |
+   |-----------|-------|--------|---------|
+   | Magic link | 5/hour | per email | Auth abuse prevention |
+   | Question generation | 100/hour | per IP | API protection |
+   | Review interaction | 1000/hour | per user | FSRS state protection |
+   | Feedback submission | 100/hour | per user | Spam prevention |
+   | Phrasing generation | 50/hour | per user | AI cost protection |
+   | Bulk actions | 100/hour | per user | Database protection |
 
 3. **Input Sanitization**
    - AI prompt injection prevention

--- a/tests/convex/rateLimit.test.ts
+++ b/tests/convex/rateLimit.test.ts
@@ -328,6 +328,7 @@ describe('Rate limit bandwidth guards', () => {
       count: 1_200,
       startTimestamp: NOW - 5000,
       intervalMs: 1,
+      operation: 'magicLink',
     });
 
     const ctx = createRateLimitCtx(attempts);
@@ -397,6 +398,7 @@ describe('Rate limit behavior', () => {
         identifier: 'ip-allow',
         count: 2,
         startTimestamp: NOW - 1000,
+        operation: 'magicLink',
       })
     );
 
@@ -413,6 +415,7 @@ describe('Rate limit behavior', () => {
         identifier: 'ip-block',
         count: limit.maxAttempts,
         startTimestamp: NOW - 1000,
+        operation: 'magicLink',
       })
     );
 
@@ -422,9 +425,8 @@ describe('Rate limit behavior', () => {
       retryAfter: expect.any(Number),
       message: limit.errorMessage,
     });
-    // No extra insert when blocked
     expect(ctx.db.tables.rateLimits.filter((r) => r.identifier === 'ip-block').length).toBe(
-      limit.maxAttempts
+      limit.maxAttempts + 1
     );
   });
 
@@ -435,6 +437,7 @@ describe('Rate limit behavior', () => {
         identifier: 'user-interaction',
         count: limit.maxAttempts,
         startTimestamp: NOW - 1000,
+        operation: 'recordInteraction',
       })
     );
 
@@ -445,7 +448,7 @@ describe('Rate limit behavior', () => {
       message: limit.errorMessage,
     });
     expect(ctx.db.tables.rateLimits.filter((r) => r.identifier === 'user-interaction').length).toBe(
-      limit.maxAttempts
+      limit.maxAttempts + 1
     );
   });
 
@@ -456,6 +459,7 @@ describe('Rate limit behavior', () => {
         identifier: 'user-feedback',
         count: limit.maxAttempts,
         startTimestamp: NOW - 1000,
+        operation: 'recordFeedback',
       })
     );
 
@@ -466,7 +470,7 @@ describe('Rate limit behavior', () => {
       message: limit.errorMessage,
     });
     expect(ctx.db.tables.rateLimits.filter((r) => r.identifier === 'user-feedback').length).toBe(
-      limit.maxAttempts
+      limit.maxAttempts + 1
     );
   });
 
@@ -477,6 +481,7 @@ describe('Rate limit behavior', () => {
         identifier: 'user-phrasing',
         count: limit.maxAttempts,
         startTimestamp: NOW - 1000,
+        operation: 'requestPhrasingGeneration',
       })
     );
 
@@ -487,7 +492,69 @@ describe('Rate limit behavior', () => {
       message: limit.errorMessage,
     });
     expect(ctx.db.tables.rateLimits.filter((r) => r.identifier === 'user-phrasing').length).toBe(
-      limit.maxAttempts
+      limit.maxAttempts + 1
+    );
+  });
+
+  it('isolates rate limits by operation type', async () => {
+    const feedbackLimit = RATE_LIMITS.recordFeedback;
+    const ctx = createRateLimitCtx(
+      createRateLimitEntries({
+        identifier: 'user-isolation',
+        count: feedbackLimit.maxAttempts,
+        startTimestamp: NOW - 1000,
+        operation: 'recordFeedback',
+      })
+    );
+
+    await expect(
+      enforceRateLimit(ctx as any, 'user-isolation', 'recordFeedback', false)
+    ).rejects.toMatchObject({ code: 'RATE_LIMIT_EXCEEDED' });
+
+    await expect(
+      enforceRateLimit(ctx as any, 'user-isolation', 'recordInteraction', false)
+    ).resolves.not.toThrow();
+  });
+
+  it('records attempt before checking to prevent race condition bypass', async () => {
+    const limit = RATE_LIMITS.recordFeedback;
+    const ctx = createRateLimitCtx(
+      createRateLimitEntries({
+        identifier: 'race-test',
+        count: limit.maxAttempts,
+        startTimestamp: NOW - 1000,
+        operation: 'recordFeedback',
+      })
+    );
+
+    await expect(
+      enforceRateLimit(ctx as any, 'race-test', 'recordFeedback', false)
+    ).rejects.toMatchObject({ code: 'RATE_LIMIT_EXCEEDED' });
+
+    const entries = ctx.db.tables.rateLimits.filter((row) => row.identifier === 'race-test');
+    expect(entries.length).toBe(limit.maxAttempts + 1);
+  });
+
+  it('blocks bulkAction when limit reached', async () => {
+    const limit = RATE_LIMITS.bulkAction;
+    const ctx = createRateLimitCtx(
+      createRateLimitEntries({
+        identifier: 'bulk-user',
+        count: limit.maxAttempts,
+        startTimestamp: NOW - 1000,
+        operation: 'bulkAction',
+      })
+    );
+
+    await expect(
+      enforceRateLimit(ctx as any, 'bulk-user', 'bulkAction', false)
+    ).rejects.toMatchObject({
+      code: 'RATE_LIMIT_EXCEEDED',
+      message: limit.errorMessage,
+    });
+
+    expect(ctx.db.tables.rateLimits.filter((r) => r.identifier === 'bulk-user').length).toBe(
+      limit.maxAttempts + 1
     );
   });
 
@@ -497,6 +564,7 @@ describe('Rate limit behavior', () => {
       identifier: 'status@example.com',
       count: 3,
       startTimestamp: NOW - 5000,
+      operation: 'magicLink',
     });
     const ctx = createRateLimitCtx(attempts);
 
@@ -520,6 +588,7 @@ describe('Rate limit behavior', () => {
       identifier: '10.0.0.1',
       count: limit.maxAttempts,
       startTimestamp: NOW - 2000,
+      operation: 'magicLink',
     });
     const ctx = createRateLimitCtx(attempts);
 
@@ -540,6 +609,7 @@ describe('Rate limit behavior', () => {
       identifier: '10.0.0.2',
       count: 2,
       startTimestamp: NOW - 2000,
+      operation: 'magicLink',
     });
     const ctx = createRateLimitCtx(attempts);
 
@@ -602,15 +672,16 @@ function createRateLimitEntries(params: {
   count: number;
   startTimestamp: number;
   intervalMs?: number;
+  operation?: string;
 }): RateLimitRow[] {
-  const { identifier, count, startTimestamp, intervalMs = 5 } = params;
+  const { identifier, count, startTimestamp, intervalMs = 5, operation = 'default' } = params;
   return Array.from({ length: count }, (_, i) => {
     const timestamp = startTimestamp + i * intervalMs;
     return {
       _id: `${identifier}_${i}`,
       _creationTime: timestamp,
       identifier,
-      operation: 'default',
+      operation,
       timestamp,
     } satisfies RateLimitRow;
   });


### PR DESCRIPTION
## Summary
- Adds per-user rate limiting to three mutations that previously bypassed rate limiting
- `recordInteraction`: 1000/hour (prevents FSRS state manipulation)
- `recordFeedback`: 100/hour (prevents feedback spam)
- `requestPhrasingGeneration`: 50/hour (prevents AI provider DoS)

Closes #195

## Test plan
- [x] Unit tests for all three new rate limit types
- [x] All 1030 tests pass
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced operation-specific rate limiting for key user actions including feedback submission, phrasing generation, review interactions, and bulk operations.
  * Rate limit enforcement now occurs after input validation to prevent unnecessary quota consumption.

* **Documentation**
  * Updated security policy with detailed rate-limiting schema and operational limits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->