### PR TITLE
fix(ci): add api-key to cerberus verdict step

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -47,3 +47,4 @@ jobs:
       - uses: misty-step/cerberus/verdict@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          api-key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
The `verdict` job in cerberus.yml was missing `api-key: ${{ secrets.OPENROUTER_API_KEY }}`, causing the Council Verdict step to fail after all review jobs completed. The review jobs already pass this correctly — this aligns the verdict step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enable API authentication for automated code review capabilities in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->