### PR TITLE
feat: add PostHog respect_dnt + Helicone LLM tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,6 +164,16 @@ GOOGLE_AI_API_KEY=AIza...
 NEXT_PUBLIC_APP_URL=https://www.scry.study
 
 # ------------------------------------------------------------------------------
+# LLM OBSERVABILITY (Helicone)
+# ------------------------------------------------------------------------------
+
+# Helicone API Key (optional — enables LLM cost tracking via gateway proxy)
+# Get from: https://helicone.ai → Settings → API Keys
+# Where to set: Convex (production), .env.local (dev)
+# Used by: convex/embeddings.ts, convex/health.ts, convex/aiGeneration.ts
+HELICONE_API_KEY=sk-helicone-...
+
+# ------------------------------------------------------------------------------
 # LLM OBSERVABILITY (Langfuse)
 # ------------------------------------------------------------------------------
 

--- a/components/providers/PostHogProvider.tsx
+++ b/components/providers/PostHogProvider.tsx
@@ -43,6 +43,7 @@ export function PostHogProvider({ children }: { children: ReactNode }) {
       person_profiles: 'identified_only',
       capture_pageview: false, // We capture manually for SPA navigation
       capture_pageleave: true,
+      respect_dnt: true,
       mask_all_text: true, // Prevent autocapture from sending text content
       autocapture: {
         dom_event_allowlist: ['click', 'submit'],

--- a/convex/embeddings.ts
+++ b/convex/embeddings.ts
@@ -96,7 +96,19 @@ export const generateEmbedding = internalAction({
       throw new Error('GOOGLE_AI_API_KEY not configured');
     }
 
-    const google = createGoogleGenerativeAI({ apiKey });
+    const heliconeApiKey = process.env.HELICONE_API_KEY;
+    const google = createGoogleGenerativeAI({
+      apiKey,
+      ...(heliconeApiKey && {
+        baseURL: 'https://gateway.helicone.ai/v1beta',
+        headers: {
+          'Helicone-Auth': `Bearer ${heliconeApiKey}`,
+          'Helicone-Target-Url': 'https://generativelanguage.googleapis.com',
+          'Helicone-Property-Product': 'scry',
+          'Helicone-Property-Environment': process.env.NODE_ENV ?? 'development',
+        },
+      }),
+    });
 
     try {
       const { embedding } = await embed({

--- a/convex/health.ts
+++ b/convex/health.ts
@@ -85,7 +85,19 @@ async function runGoogleApiKeyTest(): Promise<GoogleApiKeyTestResult> {
   }
 
   try {
-    const google = createGoogleGenerativeAI({ apiKey });
+    const heliconeApiKey = process.env.HELICONE_API_KEY;
+    const google = createGoogleGenerativeAI({
+      apiKey,
+      ...(heliconeApiKey && {
+        baseURL: 'https://gateway.helicone.ai/v1beta',
+        headers: {
+          'Helicone-Auth': `Bearer ${heliconeApiKey}`,
+          'Helicone-Target-Url': 'https://generativelanguage.googleapis.com',
+          'Helicone-Property-Product': 'scry',
+          'Helicone-Property-Environment': process.env.NODE_ENV ?? 'development',
+        },
+      }),
+    });
     await generateText({
       model: google('gemini-3-flash'),
       prompt: 'hi',


### PR DESCRIPTION
## Summary
Add privacy compliance to PostHog and enable LLM cost tracking via Helicone gateway proxy.

## Changes
- PostHog: add `respect_dnt: true` for Do Not Track compliance
- Helicone: proxy Google AI SDK calls through gateway in `convex/embeddings.ts` and `convex/health.ts`
- Helicone: gated on `HELICONE_API_KEY` presence (graceful no-op if unset)
- Updated `.env.example` with Helicone configuration section

## Test plan
- [ ] Verify PostHog events still fire with DNT disabled
- [ ] Set `HELICONE_API_KEY` in Convex env, verify requests appear in Helicone dashboard
- [ ] Verify embedding generation works without `HELICONE_API_KEY` set (graceful fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for optional Helicone API integration to enhance observability capabilities.
  * Enabled Do Not Track (DNT) respect in user tracking configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->