### PR TITLE
fix(ci): skip Cerberus review for Dependabot PRs

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   review:
     name: "${{ matrix.reviewer }}"
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -44,7 +45,11 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Skip verdict for Dependabot
+        if: github.actor == 'dependabot[bot]'
+        run: echo "Cerberus skipped for Dependabot — OPENROUTER_API_KEY unavailable"
       - uses: misty-step/cerberus/verdict@v1
+        if: github.actor != 'dependabot[bot]'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           api-key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
## Summary

GitHub does not pass `OPENROUTER_API_KEY` (or any org secrets) to Dependabot PRs by security policy. Without this fix, all 5 Cerberus review jobs fail immediately with "Missing API key", and Council Verdict fails too — making Dependabot PRs permanently blocked on Cerberus.

## Changes

- `cerberus.yml`: add `if: github.actor != 'dependabot[bot]'` to `review` job matrix
- `cerberus.yml`: `verdict` job exits 0 early for Dependabot, runs `cerberus/verdict@v1` normally for all other actors

## Why this approach

Cerberus review is meaningless for dependency bumps — the reviewer would only see lockfile diffs. Dependabot PRs with green CI (`quality` + `test`) and no security alerts can auto-merge without code review.

## Closes / Supersedes

Supersedes #251 and #253 (both were based on stale master and have since been made redundant by #246 and #247).

🤖 Generated with [Claude Code](https://claude.com/claude-code)