### PR TITLE
fix: repair trufflehog push workflow

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -18,10 +18,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Run TruffleHog
+      - name: Run TruffleHog (pull request)
+        if: github.event_name == 'pull_request'
         uses: trufflesecurity/trufflehog@v3.88.32
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
+          extra_args: --only-verified
+      - name: Run TruffleHog (push)
+        if: github.event_name != 'pull_request'
+        uses: trufflesecurity/trufflehog@v3.88.32
+        with:
+          path: ./
           extra_args: --only-verified


### PR DESCRIPTION
## Summary
- run TruffleHog with explicit `base/head` only on pull requests
- let push events use the action's native push scanning path
- keep verified-only secret scanning unchanged

## Verification
- pnpm lint
- pnpm tsc --noEmit
- pnpm test:ci
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to optimize secret scanning execution. The process now runs different configurations based on the event type, improving efficiency for both pull requests and push events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->