### PR TITLE
feat: route fsrs scheduling through memory-engine

### DIFF
--- a/backlog.d/009-fix-bun-test-oracle.md
+++ b/backlog.d/009-fix-bun-test-oracle.md
@@ -1,0 +1,33 @@
+# Fix Bun Test Oracle
+
+Priority: high
+Status: ready
+Estimate: S
+
+## Goal
+
+Make Scry's top-level test oracle truthful. `bun test` currently fails in unrelated frontend and Vitest-specific paths, so operators cannot use it as a reliable repo gate.
+
+## Non-Goals
+
+- No broad test rewrite.
+- No migration away from Vitest.
+- No attempt to fix every currently failing test in one ticket.
+
+## Oracle
+
+- [ ] `package.json` no longer implies `bun test` is the primary repo test gate when the suite requires Vitest/jsdom semantics
+- [ ] One canonical test command is documented and wired for operators and CI
+- [ ] Repo-level failures under that canonical command are either fixed or explicitly split into follow-up backlog items
+- [ ] The failure modes found on `2026-04-18` are captured:
+  - React Testing Library tests failing under Bun with `document is not defined`
+  - Vitest mocks failing under Bun with `vi.mocked is not a function`
+
+## Notes
+
+Observed while wiring `memory-engine` canary ticket 10. The FSRS seam passed under the native Scry runner:
+
+- `corepack pnpm@10.12.1 tsc --noEmit`
+- `corepack pnpm@10.12.1 exec vitest --run tests/convex/memory-engine-adapter.test.ts tests/convex/fsrs.engine.test.ts tests/convex/fsrs.test.ts convex/fsrs/conceptScheduler.test.ts`
+
+But `bun test` failed in unrelated app and AI-generation paths, so the broken oracle should be fixed at the repo level rather than copied into downstream tickets.

--- a/backlog.d/009-fix-bun-test-oracle.md
+++ b/backlog.d/009-fix-bun-test-oracle.md
@@ -28,6 +28,6 @@ Make Scry's top-level test oracle truthful. `bun test` currently fails in unrela
 Observed while wiring `memory-engine` canary ticket 10. The FSRS seam passed under the native Scry runner:
 
 - `corepack pnpm@10.12.1 tsc --noEmit`
-- `corepack pnpm@10.12.1 exec vitest --run tests/convex/memory-engine-adapter.test.ts tests/convex/fsrs.engine.test.ts tests/convex/fsrs.test.ts convex/fsrs/conceptScheduler.test.ts`
+- `corepack pnpm@10.12.1 exec vitest --run tests/convex/memory-engine-adapter.test.ts tests/convex/fsrs.test.ts convex/fsrs/conceptScheduler.test.ts`
 
 But `bun test` failed in unrelated app and AI-generation paths, so the broken oracle should be fixed at the repo level rather than copied into downstream tickets.

--- a/convex/fsrs/engine.ts
+++ b/convex/fsrs/engine.ts
@@ -1,9 +1,19 @@
-import { Card, createEmptyCard, FSRS, generatorParameters, Grade, Rating, State } from 'ts-fsrs';
-import type { Doc } from '../_generated/dataModel';
+import {
+  Rating as MemoryEngineRating,
+  next as scheduleNext,
+  type ScheduleState,
+} from 'memory-engine';
+import { Card, createEmptyCard, FSRS, generatorParameters, State, type Grade } from 'ts-fsrs';
+import {
+  conceptFsrsStateToScheduleState,
+  mapDbStateToFsrs,
+  mapFsrsStateToDb,
+  scheduleStateToConceptFsrsState,
+  type ConceptFsrsState,
+  type ConceptState,
+} from './memoryEngineAdapter';
 
-export type ConceptDoc = Doc<'concepts'>;
-export type ConceptFsrsState = ConceptDoc['fsrs'];
-export type ConceptState = NonNullable<ConceptFsrsState['state']>;
+export type { ConceptDoc, ConceptFsrsState, ConceptState } from './memoryEngineAdapter';
 
 const DEFAULT_PARAMS = generatorParameters({
   maximum_interval: 365,
@@ -37,9 +47,13 @@ export class FsrsEngine {
 
   schedule({ state, isCorrect, now = new Date() }: ScheduleArgs): ScheduleResult {
     const rating = this.ratingFromCorrectness(isCorrect);
-    const currentCard = this.stateToCard(state, now);
-    const { card: updatedCard } = this.fsrs.next(currentCard, now, rating);
-    const nextState = this.cardToState(updatedCard);
+    const updatedScheduleState = scheduleNext(
+      conceptFsrsStateToScheduleState(state, now),
+      rating,
+      now.getTime()
+    );
+    const updatedCard = this.scheduleStateToCard(updatedScheduleState);
+    const nextState = scheduleStateToConceptFsrsState(updatedScheduleState);
 
     nextState.retrievability = this.fsrs.get_retrievability(updatedCard, now, false) as number;
 
@@ -73,73 +87,52 @@ export class FsrsEngine {
   }
 
   private ratingFromCorrectness(isCorrect: boolean): Grade {
-    return isCorrect ? Rating.Good : Rating.Again;
+    return isCorrect ? MemoryEngineRating.Good : MemoryEngineRating.Again;
   }
 
   private stateToCard(state?: ConceptFsrsState | null, now: Date = new Date()): Card {
-    if (!state || state.nextReview === undefined) {
+    const scheduleState = conceptFsrsStateToScheduleState(state, now);
+
+    if (scheduleState === null) {
       return createEmptyCard(now);
     }
 
-    const dbState: ConceptState = state.state ?? 'new';
+    return this.scheduleStateToCard(scheduleState);
+  }
+
+  private scheduleStateToCard(state: ScheduleState): Card {
+    const { last_review, ...rest } = state;
+
+    if (last_review === null) {
+      return {
+        ...rest,
+        due: new Date(state.due),
+        learning_steps: 0,
+      };
+    }
 
     return {
-      due: new Date(state.nextReview),
-      stability: state.stability ?? 0,
-      difficulty: state.difficulty ?? 0,
-      elapsed_days: state.elapsedDays ?? 0,
-      scheduled_days: state.scheduledDays ?? 0,
-      reps: state.reps ?? 0,
-      lapses: state.lapses ?? 0,
-      state: this.mapDbStateToFsrs(dbState),
-      last_review: state.lastReview ? new Date(state.lastReview) : undefined,
+      ...rest,
+      due: new Date(state.due),
+      last_review: new Date(last_review),
       learning_steps: 0,
     };
   }
 
   private cardToState(card: Card): ConceptFsrsState {
-    return {
-      stability: card.stability,
-      difficulty: card.difficulty,
-      lastReview: card.last_review?.getTime(),
-      nextReview: card.due.getTime(),
-      elapsedDays: card.elapsed_days,
-      retrievability: undefined,
-      scheduledDays: card.scheduled_days,
-      reps: card.reps,
-      lapses: card.lapses,
-      state: this.mapFsrsStateToDb(card.state),
-    };
+    return scheduleStateToConceptFsrsState({
+      ...card,
+      due: card.due.getTime(),
+      last_review: card.last_review?.getTime() ?? null,
+    });
   }
 
   private mapDbStateToFsrs(state: ConceptState): State {
-    switch (state) {
-      case 'new':
-        return State.New;
-      case 'learning':
-        return State.Learning;
-      case 'review':
-        return State.Review;
-      case 'relearning':
-        return State.Relearning;
-      default:
-        return State.New;
-    }
+    return mapDbStateToFsrs(state);
   }
 
   private mapFsrsStateToDb(state: State): ConceptState {
-    switch (state) {
-      case State.New:
-        return 'new';
-      case State.Learning:
-        return 'learning';
-      case State.Review:
-        return 'review';
-      case State.Relearning:
-        return 'relearning';
-      default:
-        return 'new';
-    }
+    return mapFsrsStateToDb(state);
   }
 }
 

--- a/convex/fsrs/memoryEngineAdapter.ts
+++ b/convex/fsrs/memoryEngineAdapter.ts
@@ -1,0 +1,73 @@
+import type { ScheduleState } from 'memory-engine';
+import { State } from 'ts-fsrs';
+import type { Doc } from '../_generated/dataModel';
+
+export type ConceptDoc = Doc<'concepts'>;
+export type ConceptFsrsState = ConceptDoc['fsrs'];
+export type ConceptState = NonNullable<ConceptFsrsState['state']>;
+
+export function conceptFsrsStateToScheduleState(
+  state?: ConceptFsrsState | null,
+  _now?: Date
+): ScheduleState | null {
+  if (!state || state.nextReview === undefined) {
+    return null;
+  }
+
+  return {
+    due: state.nextReview,
+    stability: state.stability ?? 0,
+    difficulty: state.difficulty ?? 0,
+    elapsed_days: state.elapsedDays ?? 0,
+    scheduled_days: state.scheduledDays ?? 0,
+    reps: state.reps ?? 0,
+    lapses: state.lapses ?? 0,
+    state: mapDbStateToFsrs(state.state ?? 'new'),
+    last_review: state.lastReview ?? null,
+  };
+}
+
+export function scheduleStateToConceptFsrsState(state: ScheduleState): ConceptFsrsState {
+  return {
+    stability: state.stability,
+    difficulty: state.difficulty,
+    lastReview: state.last_review ?? undefined,
+    nextReview: state.due,
+    elapsedDays: state.elapsed_days,
+    retrievability: undefined,
+    scheduledDays: state.scheduled_days,
+    reps: state.reps,
+    lapses: state.lapses,
+    state: mapFsrsStateToDb(state.state),
+  };
+}
+
+export function mapDbStateToFsrs(state: ConceptState): State {
+  switch (state) {
+    case 'new':
+      return State.New;
+    case 'learning':
+      return State.Learning;
+    case 'review':
+      return State.Review;
+    case 'relearning':
+      return State.Relearning;
+    default:
+      return State.New;
+  }
+}
+
+export function mapFsrsStateToDb(state: State): ConceptState {
+  switch (state) {
+    case State.New:
+      return 'new';
+    case State.Learning:
+      return 'learning';
+    case State.Review:
+      return 'review';
+    case State.Relearning:
+      return 'relearning';
+    default:
+      return 'new';
+  }
+}

--- a/docs/architecture/root-topology-inventory.md
+++ b/docs/architecture/root-topology-inventory.md
@@ -34,7 +34,6 @@ Create a full root-level inventory and classify each item so follow-up cleanup s
 .groom
 .lighthouserc.js
 .mcp.json
-.next
 .npmrc
 .pi
 .playwright-mcp

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "date-fns": "^4.1.0",
     "langfuse": "^3.38.6",
     "lucide-react": "^0.563.0",
+    "memory-engine": "file:../memory-engine",
     "next": "16.1.6",
     "next-themes": "^0.4.6",
     "pino": "^10.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
+      memory-engine:
+        specifier: file:../memory-engine
+        version: file:../memory-engine
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4338,9 +4341,6 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
-
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
@@ -6853,6 +6853,10 @@ packages:
   memjs@1.3.2:
     resolution: {integrity: sha512-qUEg2g8vxPe+zPn09KidjIStHPtoBO8Cttm8bgJFWWabbsjQ9Av9Ky+6UcvKx6ue0LLb/LEhtcyQpRyKfzeXcg==}
     engines: {node: '>=0.10.0'}
+
+  memory-engine@file:../memory-engine:
+    resolution: {directory: ../memory-engine, type: directory}
+    engines: {bun: '>=1.3.0'}
 
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
@@ -13930,17 +13934,17 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
-  ajv-formats@2.1.1(ajv@8.17.1):
+  ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv-keywords@5.1.0(ajv@8.17.1):
+  ajv-keywords@5.1.0(ajv@8.18.0):
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -13949,13 +13953,6 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.17.1:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   ajv@8.18.0:
     dependencies:
@@ -16705,6 +16702,10 @@ snapshots:
   memjs@1.3.2:
     optional: true
 
+  memory-engine@file:../memory-engine:
+    dependencies:
+      ts-fsrs: 5.2.3
+
   memory-pager@1.5.0:
     optional: true
 
@@ -18142,9 +18143,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 2.1.1(ajv@8.18.0)
+      ajv-keywords: 5.1.0(ajv@8.18.0)
 
   seedrandom@3.0.5: {}
 

--- a/tests/convex/fsrs.test.ts
+++ b/tests/convex/fsrs.test.ts
@@ -100,13 +100,19 @@ describe('conceptScheduler', () => {
   it('supports incorrect answers transitioning to relearning', () => {
     let concept = createConcept();
 
-    // Graduate concept with a few correct answers
-    for (let i = 0; i < 3; i++) {
-      const result = scheduleConceptReview(concept, true, { now: fixedNow, engine });
+    // Graduate concept to review by answering at each due time.
+    for (let i = 0; i < 8 && concept.fsrs.state !== 'review'; i++) {
+      const reviewAt = new Date(Math.max(fixedNow.getTime(), concept.fsrs.nextReview));
+      const result = scheduleConceptReview(concept, true, { now: reviewAt, engine });
       concept = { ...concept, fsrs: result.fsrs };
     }
 
-    const relapse = scheduleConceptReview(concept, false, { now: fixedNow, engine });
+    expect(concept.fsrs.state).toBe('review');
+
+    const relapse = scheduleConceptReview(concept, false, {
+      now: new Date(concept.fsrs.nextReview),
+      engine,
+    });
     expect(relapse.state).toBe('relearning');
     expect(relapse.fsrs.lapses).toBeGreaterThanOrEqual(1);
   });

--- a/tests/convex/memory-engine-adapter.test.ts
+++ b/tests/convex/memory-engine-adapter.test.ts
@@ -1,0 +1,50 @@
+import { next, Rating } from 'memory-engine';
+import { describe, expect, it } from 'vitest';
+import { FsrsEngine } from '../../convex/fsrs/engine';
+import {
+  conceptFsrsStateToScheduleState,
+  scheduleStateToConceptFsrsState,
+  type ConceptFsrsState,
+} from '../../convex/fsrs/memoryEngineAdapter';
+
+const fixedNow = new Date('2025-01-16T12:00:00Z');
+
+const reviewState: ConceptFsrsState = {
+  stability: 3.2,
+  difficulty: 2.4,
+  lastReview: fixedNow.getTime() - 86_400_000,
+  nextReview: fixedNow.getTime() + 3_600_000,
+  elapsedDays: 1,
+  retrievability: undefined,
+  scheduledDays: 2,
+  reps: 4,
+  lapses: 1,
+  state: 'review',
+};
+
+describe('memory-engine canary adapter', () => {
+  it('round-trips Scry concept state through memory-engine schedule state', () => {
+    const scheduleState = conceptFsrsStateToScheduleState(reviewState, fixedNow);
+
+    expect(scheduleState).not.toBeNull();
+    expect(scheduleState).toMatchObject({
+      due: reviewState.nextReview,
+      last_review: reviewState.lastReview,
+      elapsed_days: reviewState.elapsedDays,
+      scheduled_days: reviewState.scheduledDays,
+      reps: reviewState.reps,
+      lapses: reviewState.lapses,
+    });
+    expect(scheduleStateToConceptFsrsState(scheduleState!)).toEqual(reviewState);
+  });
+
+  it('schedules via memory-engine and preserves Scry state shape', () => {
+    const engine = new FsrsEngine();
+    const expected = scheduleStateToConceptFsrsState(
+      next(conceptFsrsStateToScheduleState(reviewState, fixedNow), Rating.Good, fixedNow.getTime())
+    );
+    const actual = engine.schedule({ state: reviewState, isCorrect: true, now: fixedNow }).state;
+
+    expect({ ...actual, retrievability: undefined }).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- route Scry's FSRS scheduling through `memory-engine` behind a consumer-owned adapter
- add adapter parity tests and tighten the relearning oracle to use the real due timeline
- record the broken top-level `bun test` oracle as a follow-up backlog item

## Verification
- `corepack pnpm@10.12.1 tsc --noEmit`
- `corepack pnpm@10.12.1 exec vitest --run tests/convex/memory-engine-adapter.test.ts tests/convex/fsrs.test.ts convex/fsrs/conceptScheduler.test.ts`
- pre-push hooks: `test:contract` and changed-file Vitest pass

## Context
- memory-engine ticket: `/Users/phaedrus/Development/memory-engine/backlog.d/_done/10-scry-canary.md`
- follow-up backlog: `backlog.d/009-fix-bun-test-oracle.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated memory-engine library for enhanced spaced repetition scheduling and review timing.

* **Bug Fixes**
  * Fixed test oracle configuration to properly handle Bun test requirements.

* **Tests**
  * Added comprehensive test coverage for scheduling adapter integration.
  * Enhanced FSRS scheduling tests with improved review timing advancement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->