### PR TITLE
fix(evals): use openrouter grader for promptfoo rubrics

### DIFF
--- a/evals/promptfoo-phrasing.yaml
+++ b/evals/promptfoo-phrasing.yaml
@@ -25,6 +25,9 @@ commandLineOptions:
 
 defaultTest:
   options:
+    # llm-rubric assertions must use the same keyed provider family in CI;
+    # otherwise promptfoo falls back to a default grader that needs OPENAI_API_KEY.
+    provider: openrouter:google/gemini-3.1-pro-preview
     transform: |
       const jsonMatch = output.match(/\{[\s\S]*\}/);
       return jsonMatch ? jsonMatch[0].trim() : output.trim();

--- a/evals/promptfoo.yaml
+++ b/evals/promptfoo.yaml
@@ -26,6 +26,9 @@ commandLineOptions:
 # Global test configuration
 defaultTest:
   options:
+    # llm-rubric assertions must use the same keyed provider family in CI;
+    # otherwise promptfoo falls back to a default grader that needs OPENAI_API_KEY.
+    provider: openrouter:google/gemini-3.1-pro-preview
     # Strip thinking content and markdown, extract JSON object
     transform: |
       const jsonMatch = output.match(/\{[\s\S]*\}/);


### PR DESCRIPTION
## Summary
- force promptfoo `llm-rubric` assertions to use the OpenRouter Gemini provider
- prevents CI prompt evaluation from falling back to an unavailable OpenAI grader key

## Verification
- YAML parse passed for both promptfoo configs
- Prettier check passed
- `env -u OPENAI_API_KEY -u GOOGLE_API_KEY -u GEMINI_API_KEY ... promptfoo eval -c evals/promptfoo.yaml --filter-pattern "Quantum Entanglement"` passed with 0 errors
- `env -u OPENAI_API_KEY -u GOOGLE_API_KEY -u GEMINI_API_KEY ... promptfoo eval -c evals/promptfoo-phrasing.yaml --filter-first-n 1` produced expected quality failure with 0 errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated evaluation test configurations to explicitly specify the Gemini provider for assertion execution, ensuring consistent behavior in CI environments and eliminating dependency on alternative API credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->